### PR TITLE
refactor: organize main configuration

### DIFF
--- a/lua/main.lua
+++ b/lua/main.lua
@@ -1,97 +1,108 @@
+-- ==========================================================================
+--  Basic Settings
+-- ==========================================================================
 vim.g.mapleader = " "
 vim.g.loaded_netrw = 1
 vim.g.loaded_netrwPlugin = 1
-
--- optionally enable 24-bit colour
 vim.opt.termguicolors = true
+
+local keymap = vim.keymap.set
+local api = vim.api
+
+-- ==========================================================================
+--  UI & Editor Plugins
+-- ==========================================================================
+
+-- Treesitter
 require("nvim-treesitter.configs").setup({
     ensure_installed = { "python", "lua", "javascript", "html", "css" },
     highlight = {
         enable = true,
         additional_vim_regex_highlighting = false,
     },
-    indent = {
-        enable = true,
-    },
-    })
+    indent = { enable = true },
+})
+
+-- Nvim-tree
 require("nvim-tree").setup({
     update_focused_file = {
         enable = true,
         update_cwd = true,
     },
-    sort = {
-        sorter = "case_sensitive",
-    },
-    view = {
-        width = 50,
-    },
-    renderer = {
-        group_empty = true,
-    },
+    sort = { sorter = "case_sensitive" },
+    view = { width = 50 },
+    renderer = { group_empty = true },
     filters = {
         dotfiles = false,
         git_ignored = false,
     },
 })
-require("lualine").setup({
-  sections = {
-    lualine_a = { 'mode' },
-    lualine_b = { 'branch', 'diff', 'diagnostics' },
-    lualine_c = {
-        {
-            function()
-                return vim.fn.expand('%:~:.')
-            end,
-            color = { gui = 'bold' },
-        },
-    },
 
-    lualine_x = {
-        {
-          function()
-            local utc = os.time(os.date("!*t"))
-            local jst = utc + 9 * 3600
-            return os.date("%H:%M:%S", jst)
-          end,
-          icon = '',
+-- Lualine
+require("lualine").setup({
+    sections = {
+        lualine_a = { "mode" },
+        lualine_b = { "branch", "diff", "diagnostics" },
+        lualine_c = {
+            {
+                function()
+                    return vim.fn.expand("%:~:.")
+                end,
+                color = { gui = "bold" },
+            },
         },
-        { 'encoding', 'fileformat', 'filetype' }
+        lualine_x = {
+            {
+                function()
+                    local utc = os.time(os.date("!*t"))
+                    local jst = utc + 9 * 3600
+                    return os.date("%H:%M:%S", jst)
+                end,
+                icon = "",
+            },
+            { "encoding", "fileformat", "filetype" },
+        },
+        lualine_y = { "progress" },
+        lualine_z = { "location" },
     },
-    lualine_y = { 'progress' },
-    lualine_z = { 'location' }
-  }
 })
-require('telescope').setup({
-  defaults = {
-    file_ignore_patterns = {
-      "node_modules",
-      "%.git/",
-      "target",           -- Rust
-      "%.o", "%.a",       -- 编译文件
-      "__pycache__",
-      "%.pyc",
-      "venv/",
-      "env/",
-      "%.jpg", "%.png", "%.webp",
-      "%.lock",
+
+-- Telescope
+require("telescope").setup({
+    defaults = {
+        file_ignore_patterns = {
+            "node_modules",
+            "%.git/",
+            "target", -- Rust
+            "%.o",
+            "%.a", -- 编译文件
+            "__pycache__",
+            "%.pyc",
+            "venv/",
+            "env/",
+            "%.jpg",
+            "%.png",
+            "%.webp",
+            "%.lock",
+        },
     },
-  },
 })
-require('telescope').load_extension('luasnip')
+require("telescope").load_extension("luasnip")
+
+-- Misc UI plugins
 require("noice").setup()
 require("mason").setup()
 require("tint").setup({
-  tint = -30,
-  saturation = 0.6,
-  highlight_ignore_patterns = {
-    "WinSeparator",
-    "Status.*",
-    "IndentBlankline.*",
-  },
+    tint = -30,
+    saturation = 0.6,
+    highlight_ignore_patterns = {
+        "WinSeparator",
+        "Status.*",
+        "IndentBlankline.*",
+    },
 })
-require('smear_cursor').setup({
-})
-require('barbar').setup({
+require("smear_cursor").setup({})
+require("barbar").setup({
     animation = true,
     auto_hide = false,
     tabpages = true,
@@ -105,15 +116,20 @@ require("osc52").setup({
     trim = false,
 })
 
-vim.api.nvim_create_autocmd('TextYankPost', {
-  callback = function()
-    if vim.v.event.operator == 'y' and vim.v.event.regname == '+' then
-      require('osc52').copy_register('+')
-    end
-  end,
+api.nvim_create_autocmd("TextYankPost", {
+    callback = function()
+        if vim.v.event.operator == "y" and vim.v.event.regname == "+" then
+            require("osc52").copy_register("+")
+        end
+    end,
 })
 
+-- ==========================================================================
+--  LSP & Diagnostics
+-- ==========================================================================
+
 local lspconfig = require("lspconfig")
+
 lspconfig.pyright.setup({
     root_dir = function(fname)
         local project_root = require("lspconfig.util").find_git_ancestor(fname)
@@ -121,12 +137,11 @@ lspconfig.pyright.setup({
     end,
     cmd = { "/isaac-sim/pyright_with_env.sh", "--stdio" },
     settings = {
-        python = {
-            pythonPath = "/isaac-sim/kit/python/bin/python3"
-        }
-    }
+        python = { pythonPath = "/isaac-sim/kit/python/bin/python3" },
+    },
 })
-vim.keymap.set("n", "<leader>e", vim.diagnostic.open_float, { desc = "Open Diagnostic Float" })
+
+keymap("n", "<leader>e", vim.diagnostic.open_float, { desc = "Open Diagnostic Float" })
 
 lspconfig.texlab.setup({
     root_dir = function(fname)
@@ -149,9 +164,13 @@ lspconfig.texlab.setup({
     },
 })
 
+-- ==========================================================================
+--  Completion
+-- ==========================================================================
 
 local cmp = require("cmp")
 local luasnip = require("luasnip")
+
 cmp.setup({
     snippet = {
         expand = function(args)
@@ -177,7 +196,7 @@ cmp.setup({
                 fallback()
             end
         end, { "i", "s" }),
-        ['<CR>'] = cmp.mapping.confirm({ select = true }),
+        ["<CR>"] = cmp.mapping.confirm({ select = true }),
     }),
     sources = {
         { name = "nvim_lsp" },
@@ -188,348 +207,361 @@ cmp.setup({
     },
 })
 
--- coplilot setup
+-- Copilot
 vim.g.copilot_no_tab_map = true
-vim.api.nvim_set_keymap("i", "<C-l>", 'copilot#Accept("<CR>")', { expr = true, silent = true, noremap = true, desc = "Accept Copilot Suggestion" })
+api.nvim_set_keymap("i", "<C-l>", 'copilot#Accept("<CR>")', { expr = true, silent = true, noremap = true, desc = "Accept Copilot Suggestion" })
 
+-- Snippets
 require("luasnip-latex-snippets").setup({
     use_treesitter = true,
     use_ultisnips = true,
     use_latex_symbols = true,
 })
-require("luasnip").config.setup { enable_autosnippets = true }
+require("luasnip").config.setup({ enable_autosnippets = true })
 
+-- Formatting
 local null_ls = require("null-ls")
 null_ls.setup({
-  sources = {
-    null_ls.builtins.formatting.black,
-    null_ls.builtins.formatting.isort,
-  },
+    sources = {
+        null_ls.builtins.formatting.black,
+        null_ls.builtins.formatting.isort,
+    },
 })
 
-local dap = require('dap')
+-- ==========================================================================
+--  Debugging
+-- ==========================================================================
+
+local dap = require("dap")
 dap.adapters.python = {
-  type = 'executable',
-  command = '/isaac-sim/python.sh',
-  args = { '-m', 'debugpy.adapter' },
+    type = "executable",
+    command = "/isaac-sim/python.sh",
+    args = { "-m", "debugpy.adapter" },
 }
 
 dap.configurations.python = {
-  {
-    type = 'python',
-    request = 'launch',
-    name = 'Launch file',
-    program = '${file}',
-    pythonPath = function()
-      return '/isaac-sim/python.sh'
-    end,
-    cwd = '${workspaceFolder}',
-    env = {
-        CUDA_VISIBLE_DEVICES = '1',
-    }
-  },
+    {
+        type = "python",
+        request = "launch",
+        name = "Launch file",
+        program = "${file}",
+        pythonPath = function()
+            return "/isaac-sim/python.sh"
+        end,
+        cwd = "${workspaceFolder}",
+        env = { CUDA_VISIBLE_DEVICES = "1" },
+    },
 }
 
-local dap_python = require('dap-python')
-dap_python.setup('/isaac-sim/python.sh')
+local dap_python = require("dap-python")
+dap_python.setup("/isaac-sim/python.sh")
 
-vim.keymap.set('n', '<leader>db', ":lua require'dap'.toggle_breakpoint()<CR>", { desc = "Toggle Breakpoint" })
-vim.keymap.set('n', '<leader>dc', ":lua require'dap'.continue()<CR>", { desc = "Continue Debugging" })
-vim.keymap.set('n', '<leader>di', ":lua require'dap'.step_into()<CR>", { desc = "Step Into" })
-vim.keymap.set('n', '<leader>do', ":lua require'dap'.step_over()<CR>", { desc = "Step Over" })
-vim.keymap.set('n', '<leader>dr', ":lua require'dap'.repl.toggle()<CR>", { desc = "Toggle Debug REPL" })
-vim.keymap.set('n', '<leader>du', function()
-  if require("nvim-tree.api").tree.is_visible() then
-    require("nvim-tree.api").tree.close()
-  end
-  require('dapui').toggle()
+keymap("n", "<leader>db", ":lua require'dap'.toggle_breakpoint()<CR>", { desc = "Toggle Breakpoint" })
+keymap("n", "<leader>dc", ":lua require'dap'.continue()<CR>", { desc = "Continue Debugging" })
+keymap("n", "<leader>di", ":lua require'dap'.step_into()<CR>", { desc = "Step Into" })
+keymap("n", "<leader>do", ":lua require'dap'.step_over()<CR>", { desc = "Step Over" })
+keymap("n", "<leader>dr", ":lua require'dap'.repl.toggle()<CR>", { desc = "Toggle Debug REPL" })
+keymap("n", "<leader>du", function()
+    if require("nvim-tree.api").tree.is_visible() then
+        require("nvim-tree.api").tree.close()
+    end
+    require("dapui").toggle()
 end, { desc = "Toggle Debug UI" })
+keymap("n", "<leader>dt", ":lua require'dap'.terminate()<CR>", { desc = "Terminate Debug Session" })
 
-vim.keymap.set('n', '<leader>dt', ":lua require'dap'.terminate()<CR>", { desc = "Terminate Debug Session" })
-
-require('illuminate').configure({
-    providers = {
-        'lsp',
-        'treesitter',
-        'regex',
-    },
+require("illuminate").configure({
+    providers = { "lsp", "treesitter", "regex" },
     delay = 120,
     large_file_cutoff = 2000,
-    large_file_overrides = {
-        providers = { 'regex' },
-    },
+    large_file_overrides = { providers = { "regex" } },
     filetypes_denylist = {
-        'dirbuf',
-        'dirvish',
-        'fugitive',
-        'NvimTree',
-        'neo-tree',
-        'dashboard',
-        'alpha',
-        'toggleterm',
-        'TelescopePrompt',
-        'Trouble',
-        'Outline',
+        "dirbuf",
+        "dirvish",
+        "fugitive",
+        "NvimTree",
+        "neo-tree",
+        "dashboard",
+        "alpha",
+        "toggleterm",
+        "TelescopePrompt",
+        "Trouble",
+        "Outline",
     },
     under_cursor = true,
     min_count_to_highlight = 2,
     disable_keymaps = true,
 })
 
-
-require("dapui").setup(
-{
-  icons = { expanded = "▾", collapsed = "▸" },
-  mappings = {
-    expand = { "<CR>", "<2-LeftMouse>" },
-    open = "o",
-    remove = "d",
-    edit = "e",
-    repl = "r",
-  },
-  layouts = {
-    {
-      elements = {
-        { id = "scopes", size = 0.25 },
-        { id = "breakpoints", size = 0.25 },
-        { id = "stacks", size = 0.25 },
-        { id = "watches", size = 0.25 },
-      },
-      size = 40,
-      position = "left",
+require("dapui").setup({
+    icons = { expanded = "▾", collapsed = "▸" },
+    mappings = {
+        expand = { "<CR>", "<2-LeftMouse>" },
+        open = "o",
+        remove = "d",
+        edit = "e",
+        repl = "r",
     },
-    {
-      elements = {
-        { id = "repl", size = 1 },
-      },
-      size = 10,
-      position = "bottom",
+    layouts = {
+        {
+            elements = {
+                { id = "scopes", size = 0.25 },
+                { id = "breakpoints", size = 0.25 },
+                { id = "stacks", size = 0.25 },
+                { id = "watches", size = 0.25 },
+            },
+            size = 40,
+            position = "left",
+        },
+        {
+            elements = {
+                { id = "repl", size = 1 },
+            },
+            size = 10,
+            position = "bottom",
+        },
     },
-  },
 })
 
-vim.fn.sign_define('DapBreakpoint', { text='●', texthl='Error', linehl='', numhl='' })
+vim.fn.sign_define("DapBreakpoint", { text = "●", texthl = "Error", linehl = "", numhl = "" })
 
-local dap, dapui = require("dap"), require("dapui")
+local dapui = require("dapui")
 dap.listeners.after.event_initialized["dapui_config"] = function()
-  dapui.open()
+    dapui.open()
 end
 dap.listeners.before.event_terminated["dapui_config"] = function()
-  dapui.close()
+    dapui.close()
 end
 dap.listeners.before.event_exited["dapui_config"] = function()
-  dapui.close()
+    dapui.close()
 end
 
+-- LSP related keymaps
+keymap("n", "gd", vim.lsp.buf.definition, { desc = "Go to Definition" })
+keymap("n", "K", vim.lsp.buf.hover, { desc = "Hover Documentation" })
+keymap("n", "<leader>rn", vim.lsp.buf.rename, { desc = "Rename Symbol" })
+keymap("n", "<leader>ca", vim.lsp.buf.code_action, { desc = "Code Action" })
+keymap("n", "gr", vim.lsp.buf.references, { desc = "Find References" })
 
+-- ==========================================================================
+--  Utility Plugins
+-- ==========================================================================
 
-vim.keymap.set("n", "gd", vim.lsp.buf.definition, { desc = "Go to Definition" })
-vim.keymap.set("n", "K", vim.lsp.buf.hover, { desc = "Hover Documentation" })
-vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, { desc = "Rename Symbol" })
-vim.keymap.set("n", "<leader>ca", vim.lsp.buf.code_action, { desc = "Code Action" })
-vim.keymap.set("n", "gr", vim.lsp.buf.references, { desc = "Find References" })
-
--- which-key config
 require("which-key").setup({
-  -- your configuration comes here
-  -- for example, to enable the helix theme
-  plugins = {
-    spelling = {
-      enabled = true,
-      suggestions = 20,
+    plugins = {
+        spelling = {
+            enabled = true,
+            suggestions = 20,
+        },
     },
-  },
-  -- add helix theme
-  preset = "helix",
+    preset = "helix",
 })
 
--- auto-session config
 require("auto-session").setup({
-  log_level = "info",
-  auto_restore_enabled = true,
-  auto_session_enable_last_session = false,
-  auto_session_enabled = true,
-  auto_save_enabled = true,
-  auto_dap_restore = true,
-  auto_project_root_dir = vim.fn.getcwd(),
-  bypass_session_save_file_types = { "gitcommit", "gitrebase" },
+    log_level = "info",
+    auto_restore_enabled = true,
+    auto_session_enable_last_session = false,
+    auto_session_enabled = true,
+    auto_save_enabled = true,
+    auto_dap_restore = true,
+    auto_project_root_dir = vim.fn.getcwd(),
+    bypass_session_save_file_types = { "gitcommit", "gitrebase" },
 })
 
--- Move to previous/next buffer
-vim.keymap.set('n', '<A-,>', '<Cmd>BufferPrevious<CR>', { desc = "Previous Buffer", noremap = true, silent = true })
-vim.keymap.set('n', '<A-.>', '<Cmd>BufferNext<CR>', { desc = "Next Buffer", noremap = true, silent = true })
+-- ==========================================================================
+--  Buffer Navigation
+-- ==========================================================================
 
--- Re-order buffer to previous/next
-vim.keymap.set('n', '<A-<', '<Cmd>BufferMovePrevious<CR>', { desc = "Move Buffer Previous", noremap = true, silent = true })
-vim.keymap.set('n', '<A->>', '<Cmd>BufferMoveNext<CR>', { desc = "Move Buffer Next", noremap = true, silent = true })
+keymap("n", "<A-,>", "<Cmd>BufferPrevious<CR>", { desc = "Previous Buffer", noremap = true, silent = true })
+keymap("n", "<A-.>", "<Cmd>BufferNext<CR>", { desc = "Next Buffer", noremap = true, silent = true })
 
--- Goto buffer in position...
-vim.keymap.set('n', '<A-1>', '<Cmd>BufferGoto 1<CR>', { desc = "Go to Buffer 1", noremap = true, silent = true })
-vim.keymap.set('n', '<A-2>', '<Cmd>BufferGoto 2<CR>', { desc = "Go to Buffer 2", noremap = true, silent = true })
-vim.keymap.set('n', '<A-3>', '<Cmd>BufferGoto 3<CR>', { desc = "Go to Buffer 3", noremap = true, silent = true })
-vim.keymap.set('n', '<A-4>', '<Cmd>BufferGoto 4<CR>', { desc = "Go to Buffer 4", noremap = true, silent = true })
-vim.keymap.set('n', '<A-5>', '<Cmd>BufferGoto 5<CR>', { desc = "Go to Buffer 5", noremap = true, silent = true })
-vim.keymap.set('n', '<A-6>', '<Cmd>BufferGoto 6<CR>', { desc = "Go to Buffer 6", noremap = true, silent = true })
-vim.keymap.set('n', '<A-7>', '<Cmd>BufferGoto 7<CR>', { desc = "Go to Buffer 7", noremap = true, silent = true })
-vim.keymap.set('n', '<A-8>', '<Cmd>BufferGoto 8<CR>', { desc = "Go to Buffer 8", noremap = true, silent = true })
-vim.keymap.set('n', '<A-9>', '<Cmd>BufferGoto 9<CR>', { desc = "Go to Buffer 9", noremap = true, silent = true })
-vim.keymap.set('n', '<A-0>', '<Cmd>BufferLast<CR>', { desc = "Go to Last Buffer", noremap = true, silent = true })
+keymap("n", "<A-<", "<Cmd>BufferMovePrevious<CR>", { desc = "Move Buffer Previous", noremap = true, silent = true })
+keymap("n", "<A->>", "<Cmd>BufferMoveNext<CR>", { desc = "Move Buffer Next", noremap = true, silent = true })
 
--- Pin/unpin buffer
-vim.keymap.set('n', '<A-p>', '<Cmd>BufferPin<CR>', { desc = "Pin/Unpin Buffer", noremap = true, silent = true })
--- Close buffer
-vim.keymap.set('n', '<A-c>', '<Cmd>BufferClose<CR>', { desc = "Close Buffer", noremap = true, silent = true })
-vim.keymap.set('n', '<C-s-p>', '<Cmd>BufferPickDelete<CR>', { desc = "Pick and Delete Buffer", noremap = true, silent = true })
-vim.keymap.set('n', '<leader>f', '<Cmd>BufferPick<CR>', { desc = "Pick Buffer", noremap = true, silent = true })
+keymap("n", "<A-1>", "<Cmd>BufferGoto 1<CR>", { desc = "Go to Buffer 1", noremap = true, silent = true })
+keymap("n", "<A-2>", "<Cmd>BufferGoto 2<CR>", { desc = "Go to Buffer 2", noremap = true, silent = true })
+keymap("n", "<A-3>", "<Cmd>BufferGoto 3<CR>", { desc = "Go to Buffer 3", noremap = true, silent = true })
+keymap("n", "<A-4>", "<Cmd>BufferGoto 4<CR>", { desc = "Go to Buffer 4", noremap = true, silent = true })
+keymap("n", "<A-5>", "<Cmd>BufferGoto 5<CR>", { desc = "Go to Buffer 5", noremap = true, silent = true })
+keymap("n", "<A-6>", "<Cmd>BufferGoto 6<CR>", { desc = "Go to Buffer 6", noremap = true, silent = true })
+keymap("n", "<A-7>", "<Cmd>BufferGoto 7<CR>", { desc = "Go to Buffer 7", noremap = true, silent = true })
+keymap("n", "<A-8>", "<Cmd>BufferGoto 8<CR>", { desc = "Go to Buffer 8", noremap = true, silent = true })
+keymap("n", "<A-9>", "<Cmd>BufferGoto 9<CR>", { desc = "Go to Buffer 9", noremap = true, silent = true })
+keymap("n", "<A-0>", "<Cmd>BufferLast<CR>", { desc = "Go to Last Buffer", noremap = true, silent = true })
 
-vim.keymap.set('n', '<Space>bb', '<Cmd>BufferOrderByBufferNumber<CR>', { desc = "Order Buffers by Number", noremap = true, silent = true })
-vim.keymap.set('n', '<Space>bn', '<Cmd>BufferOrderByName<CR>', { desc = "Order Buffers by Name", noremap = true, silent = true })
-vim.keymap.set('n', '<Space>bd', '<Cmd>BufferOrderByDirectory<CR>', { desc = "Order Buffers by Directory", noremap = true, silent = true })
-vim.keymap.set('n', '<Space>bl', '<Cmd>BufferOrderByLanguage<CR>', { desc = "Order Buffers by Language", noremap = true, silent = true })
-vim.keymap.set('n', '<Space>bw', '<Cmd>BufferOrderByWindowNumber<CR>', { desc = "Order Buffers by Window Number", noremap = true, silent = true })
-vim.keymap.set('n', '<C-p>', ":Telescope find_files<CR>", { noremap = true, silent = true, desc = "Find Files (Telescope)" })
-vim.keymap.set('n', '<C-[>', ":Telescope luasnip<CR>", { noremap = true, silent = true, desc = "Find Snippets (Telescope)" })
-vim.keymap.set("n", "<C-b>", function()
-  pcall(function() require("dapui").close() end)
-  vim.cmd("NvimTreeToggle")
+keymap("n", "<A-p>", "<Cmd>BufferPin<CR>", { desc = "Pin/Unpin Buffer", noremap = true, silent = true })
+keymap("n", "<A-c>", "<Cmd>BufferClose<CR>", { desc = "Close Buffer", noremap = true, silent = true })
+keymap("n", "<C-s-p>", "<Cmd>BufferPickDelete<CR>", { desc = "Pick and Delete Buffer", noremap = true, silent = true })
+keymap("n", "<leader>f", "<Cmd>BufferPick<CR>", { desc = "Pick Buffer", noremap = true, silent = true })
+
+keymap("n", "<Space>bb", "<Cmd>BufferOrderByBufferNumber<CR>", { desc = "Order Buffers by Number", noremap = true, silent = true })
+keymap("n", "<Space>bn", "<Cmd>BufferOrderByName<CR>", { desc = "Order Buffers by Name", noremap = true, silent = true })
+keymap("n", "<Space>bd", "<Cmd>BufferOrderByDirectory<CR>", { desc = "Order Buffers by Directory", noremap = true, silent = true })
+keymap("n", "<Space>bl", "<Cmd>BufferOrderByLanguage<CR>", { desc = "Order Buffers by Language", noremap = true, silent = true })
+keymap("n", "<Space>bw", "<Cmd>BufferOrderByWindowNumber<CR>", { desc = "Order Buffers by Window Number", noremap = true, silent = true })
+
+keymap("n", "<C-p>", ":Telescope find_files<CR>", { noremap = true, silent = true, desc = "Find Files (Telescope)" })
+keymap("n", "<C-[>", ":Telescope luasnip<CR>", { noremap = true, silent = true, desc = "Find Snippets (Telescope)" })
+keymap("n", "<C-b>", function()
+    pcall(function()
+        require("dapui").close()
+    end)
+    vim.cmd("NvimTreeToggle")
 end, { noremap = true, silent = true, desc = "Toggle NvimTree" })
 
-vim.keymap.set('n', '<A-s>', '<Cmd>wa<CR>', { desc = "Save All Buffers", noremap = true, silent = true })
-vim.keymap.set('i', '<S-Tab>', '<C-d>', { desc = "Indent Line", noremap = true, silent = true })
+keymap("n", "<A-s>", "<Cmd>wa<CR>", { desc = "Save All Buffers", noremap = true, silent = true })
+keymap("i", "<S-Tab>", "<C-d>", { desc = "Indent Line", noremap = true, silent = true })
 
-require("toggleterm").setup{
+-- ==========================================================================
+--  Terminal & Appearance
+-- ==========================================================================
+
+require("toggleterm").setup({
     size = 15,
     shell = "/bin/zsh",
     open_mapping = [[<c-\>]],
-    direction = 'float',
-}
+    direction = "float",
+})
 
-function LineNumberColors()
-    vim.api.nvim_set_hl(0, 'LineNrAbove', { fg='#7aa2f7', bold=false })
-    vim.api.nvim_set_hl(0, 'LineNr', { fg='white', bold=true })
-    vim.api.nvim_set_hl(0, 'LineNrBelow', { fg='#f7768e', bold=false })
+local function LineNumberColors()
+    api.nvim_set_hl(0, "LineNrAbove", { fg = "#7aa2f7", bold = false })
+    api.nvim_set_hl(0, "LineNr", { fg = "white", bold = true })
+    api.nvim_set_hl(0, "LineNrBelow", { fg = "#f7768e", bold = false })
 end
 
 LineNumberColors()
 
--- vim.api.nvim_create_autocmd("VimEnter", {
---     callback = function()
---         require("duck").hatch("🐈")
---     end,
--- })
+keymap("n", "<C-d>", "15jzz", { desc = "Scroll Down 10 Lines", noremap = true, silent = true })
+keymap("n", "<C-u>", "15kzz", { desc = "Scroll Up 10 Lines", noremap = true, silent = true })
 
+-- ==========================================================================
+--  Comments & Navigation
+-- ==========================================================================
 
-vim.keymap.set('n', '<C-d>', "15jzz", { desc = "Scroll Down 10 Lines", noremap = true, silent = true })
-vim.keymap.set('n', '<C-u>', "15kzz", { desc = "Scroll Up 10 Lines", noremap = true, silent = true })
+require("Comment").setup()
+keymap("n", "<C-/>", "<Plug>(comment_toggle_linewise_current)", { desc = "Toggle Comment", noremap = true, silent = true })
+keymap("v", "<C-/>", "<Plug>(comment_toggle_linewise_visual)", { desc = "Toggle Comment", noremap = true, silent = true })
 
--- comment
-require('Comment').setup()
+require("flash").setup()
+keymap({ "n", "x", "o" }, "s", function()
+    require("flash").jump()
+end, { desc = "Flash", noremap = true, silent = true })
+keymap({ "n", "x", "o" }, "S", function()
+    require("flash").treesitter()
+end, { desc = "Treesitter", noremap = true, silent = true })
+keymap("o", "r", function()
+    require("flash").remote()
+end, { desc = "Remote Flash", noremap = true, silent = true })
+keymap({ "o", "x" }, "R", function()
+    require("flash").treesitter_search()
+end, { desc = "Treesitter Search", noremap = true, silent = true })
+keymap("c", "<C-s>", function()
+    require("flash").toggle()
+end, { desc = "Toggle Flash Search", noremap = true, silent = true })
 
-vim.keymap.set('n', '<C-/>', '<Plug>(comment_toggle_linewise_current)', { desc = "Toggle Comment", noremap = true, silent = true })
-vim.keymap.set('v', '<C-/>', '<Plug>(comment_toggle_linewise_visual)', { desc = "Toggle Comment", noremap = true, silent = true })
-
--- leap.nvim and flash.nvim configuration
--- require('leap').add_default_mappings()
-require('flash').setup()
-vim.keymap.set({ "n", "x", "o" }, "s", function() require("flash").jump() end, { desc = "Flash", noremap = true, silent = true})
-vim.keymap.set({ "n", "x", "o" }, "S", function() require("flash").treesitter() end, { desc = "Treesitter", noremap = true, silent = true })
-vim.keymap.set("o", "r", function() require("flash").remote() end, { desc = "Remote Flash", noremap = true, silent = true })
-vim.keymap.set({ "o", "x" }, "R", function() require("flash").treesitter_search() end, { desc = "Treesitter Search", noremap = true, silent = true})
-vim.keymap.set("c", "<C-s>", function() require("flash").toggle() end, { desc = "Toggle Flash Search", noremap = true, silent = true })
-
--- hop.nvim
-require('hop').setup()
-vim.keymap.set({"n", "x", "o"}, "<leader>j", function()
-    require('hop').hint_lines()
+require("hop").setup()
+keymap({ "n", "x", "o" }, "<leader>j", function()
+    require("hop").hint_lines()
 end, { desc = "Hop to Line", noremap = true, silent = true })
 
--- vimtex configuration
-vim.g.vimtex_view_method = 'skim'
+-- ==========================================================================
+--  LaTeX
+-- ==========================================================================
+
+vim.g.vimtex_view_method = "skim"
 vim.g.vimtex_view_skim_sync = 1
 vim.g.vimtex_view_skim_activate = 1
 vim.g.vimtex_view_automatic = 1
 
-vim.g.vimtex_compiler_method = 'latexmk'
+vim.g.vimtex_compiler_method = "latexmk"
 vim.g.vimtex_compiler_latexmk = {
-    backend = 'nvim',
+    backend = "nvim",
     callback = 1,
     continuous = 1,
-    executable = 'latexmk',
+    executable = "latexmk",
     options = {
-        '-pdflatex',
-        '-shell-escape',
-        '-verbose',
-        '-file-line-error',
-        '-interaction=nonstopmode',
-        '-synctex=1',
+        "-pdflatex",
+        "-shell-escape",
+        "-verbose",
+        "-file-line-error",
+        "-interaction=nonstopmode",
+        "-synctex=1",
     },
 }
 
-vim.g.tex_conceal = 'abdmg'
+vim.g.tex_conceal = "abdmg"
 
-vim.keymap.set('n', '<leader>ll', ':VimtexCompile<CR>', { desc = "Compile LaTeX", noremap = true, silent = true })
-vim.keymap.set('n', '<leader>lv', ':VimtexView<CR>', { desc = "View LaTeX", noremap = true, silent = true })
-vim.keymap.set('n', '<leader>lc', ':VimtexClean<CR>', { desc = "Clean LaTeX", noremap = true, silent = true })
-vim.keymap.set('n', '<leader>le', ':VimtexCompile<CR>:VimtexView<CR>', { desc = "Compile & View", noremap = true, silent = true })
-vim.keymap.set('v', '<leader>y', '"+y', { desc = "Yank to Clipboard", noremap = true, silent = true })
+keymap("n", "<leader>ll", ":VimtexCompile<CR>", { desc = "Compile LaTeX", noremap = true, silent = true })
+keymap("n", "<leader>lv", ":VimtexView<CR>", { desc = "View LaTeX", noremap = true, silent = true })
+keymap("n", "<leader>lc", ":VimtexClean<CR>", { desc = "Clean LaTeX", noremap = true, silent = true })
+keymap("n", "<leader>le", ":VimtexCompile<CR>:VimtexView<CR>", { desc = "Compile & View", noremap = true, silent = true })
+keymap("v", "<leader>y", '"+y', { desc = "Yank to Clipboard", noremap = true, silent = true })
 
+-- ==========================================================================
+--  Window Picker
+-- ==========================================================================
 
--- vim-window-picker configuration
-require('window-picker').setup({
-    hint = 'floating-big-letter',
+require("window-picker").setup({
+    hint = "floating-big-letter",
     autoselect_one = true,
     include_current = false,
-    selection_chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    selection_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
     filter_rules = {
         bo = {
-            filetype = { 'NvimTree', 'TelescopePrompt', 'toggleterm', 'dapui_watches' },
-            buftype = { 'terminal', 'quickfix' },
+            filetype = { "NvimTree", "TelescopePrompt", "toggleterm", "dapui_watches" },
+            buftype = { "terminal", "quickfix" },
         },
     },
-    other_win_hl_color = '#e35e4f',
+    other_win_hl_color = "#e35e4f",
 })
-vim.keymap.set('n', '<leader>w', function()
-  local picked_window_id = require('window-picker').pick_window()
-  if picked_window_id then
-    vim.api.nvim_set_current_win(picked_window_id)
-  end
-end, { desc = 'Pick a window' })
 
--- vim treesitter context
-require('treesitter-context').setup({
+keymap("n", "<leader>w", function()
+    local picked_window_id = require("window-picker").pick_window()
+    if picked_window_id then
+        api.nvim_set_current_win(picked_window_id)
+    end
+end, { desc = "Pick a window" })
+
+-- ==========================================================================
+--  Treesitter Context & Aerial
+-- ==========================================================================
+
+require("treesitter-context").setup({
     enable = true,
     max_lines = 5, -- 0 means no limit
-    trim_scope = 'inner', -- 'inner' or 'outer'
-    min_window_height = 0, -- set to 0 if you want to disable the plugin when the window height is less than this value
-    mode = 'cursor', -- 'cursor' or 'topline'
-    zindex = 20, -- set to a value higher than the current window's zindex
+    trim_scope = "inner", -- 'inner' or 'outer'
+    min_window_height = 0, -- disable when window height is below this value
+    mode = "cursor", -- 'cursor' or 'topline'
+    zindex = 20,
 })
 
--- aerial.nvim configuration
-require('aerial').setup({
-    backends = { 'treesitter', 'lsp' },
+require("aerial").setup({
+    backends = { "treesitter", "lsp" },
     show_guides = true,
     show_guide_icons = true,
     show_cursor = true,
     close_on_select = true,
-    attach_mode = 'global',
+    attach_mode = "global",
     layout = {
-        default_direction = 'float',
+        default_direction = "float",
         min_width = 30,
         max_width = 60,
         width = 40,
         preserve_equality = true,
     },
 })
-vim.keymap.set('n', '<leader>a', ':AerialToggle<CR>', { desc = "Toggle Aerial", noremap = true, silent = true })
+keymap("n", "<leader>a", ":AerialToggle<CR>", { desc = "Toggle Aerial", noremap = true, silent = true })
 
--- autopairs configuration
-require('nvim-autopairs').setup({
+-- ==========================================================================
+--  Autopairs
+-- ==========================================================================
+
+require("nvim-autopairs").setup({
     check_ts = true,
     ts_config = {
-        lua = { 'string' },
-        javascript = { 'template_string' },
+        lua = { "string" },
+        javascript = { "template_string" },
         java = false,
     },
-    disable_filetype = { 'TelescopePrompt', 'vim' },
+    disable_filetype = { "TelescopePrompt", "vim" },
 })
+


### PR DESCRIPTION
## Summary
- refactor: group editor, LSP, and tooling setups into clearly labeled sections
- streamline keymap definitions for improved readability

## Testing
- `luac -p lua/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_688cdd19c0688330a9de5c253c4fed3f